### PR TITLE
Call as module rather than as script

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,1 +1,1 @@
-run: python:latest python action/__main__.py
+run: python:latest python -m action.__main__


### PR DESCRIPTION
Calling as a module should put the module on the path, fixing absolute imports.