### PR TITLE
Assorted refactorings

### DIFF
--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Sequence, Union
 
 import pandas as pd
 
-from .find_save_tools import import_data, make_folders
+from .find_save_tools import import_data, make_output_dirs
 from .redaction_tools import make_crosstab
 
 
@@ -111,8 +111,7 @@ def output_tables(
     """
     df = import_data(pathlib.Path(data_csv), table_config)
 
-    # Make folder for tables
-    make_folders(table_config_json=table_config, path=output_dir)
+    make_output_dirs(table_config_json=table_config, path=output_dir)
 
     # Sort the json into options
     two_way_tables: Dict = {}

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -200,7 +200,7 @@ def _output_simple_two_way(
             in both sexes.
     """
     variable_names, new_table = process_table_request(
-        df, table_instructions, small_no_limit=limit
+        df, table_instructions, threshold=limit
     )
     if additional_info is not None:
         table_name_str = (

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -177,7 +177,7 @@ def output_tables(
 def _output_simple_two_way(
     df: pd.DataFrame,
     name_tables: str,
-    table_instructions: Dict,
+    table_instructions: Sequence,
     output_dir: Union[None, str] = None,
     limit: int = 5,
     additional_info: Optional[str] = None,

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Sequence, Union
 import pandas as pd
 
 from .find_save_tools import import_data, make_folders
-from .redaction_tools import process_table_request
+from .redaction_tools import make_crosstab
 
 
 def prettify_tables(table: pd.DataFrame, variables: list) -> str:
@@ -90,7 +90,7 @@ def output_tables(
 ) -> None:
     """
     Takes the list of requests for various table configurations, and processes them
-    by calling process_table_request() on each request. Each group of tables are
+    by calling make_crosstab() on each request. Each group of tables are
     put into folders by that name.
 
     The redacted tables are logged as redacted.
@@ -199,9 +199,7 @@ def _output_simple_two_way(
             tables that look similar to each other for example copd vs death,
             in both sexes.
     """
-    variable_names, new_table = process_table_request(
-        df, table_instructions, threshold=limit
-    )
+    variable_names, new_table = make_crosstab(df, table_instructions, threshold=limit)
     if additional_info is not None:
         table_name_str = (
             f"{additional_info} - {variable_names[0]} vs {variable_names[1]}"

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -111,7 +111,7 @@ def output_tables(
     """
     df = import_data(pathlib.Path(data_csv), table_config)
 
-    make_output_dirs(table_config_json=table_config, path=output_dir)
+    make_output_dirs(table_config, output_dir)
 
     # Sort the json into options
     two_way_tables: Dict = {}

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -1,4 +1,5 @@
 import itertools
+import pathlib
 from typing import Dict, Optional, Sequence, Union
 
 import pandas as pd
@@ -108,8 +109,7 @@ def output_tables(
         limit (int): limit at which should redact small numbers
 
     """
-    # Load data by calling import_data() function
-    df = import_data(data=data_csv, variable_json=table_config)
+    df = import_data(pathlib.Path(data_csv), table_config)
 
     # Make folder for tables
     make_folders(table_config_json=table_config, path=output_dir)

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -1,34 +1,35 @@
 """ this contains useful functions for loading and saving data tables"""
 import os
-from pathlib import PurePosixPath
+import pathlib
+from typing import Dict, Sequence, Union
 
 import pandas as pd
 
 from .errors import ImportActionError
 
+TableConfig = Dict[str, Union[str, Sequence[str]]]
 
-def import_data(variable_json, data="output/input.csv"):
+
+def import_data(file_path: pathlib.Path, table_configs: Dict[str, TableConfig]):
     """
     Imports data and checks that the variables are present
 
     Will accept input file as csv or dta file (stata).
     """
-    # load the data into a pandas DataFrame depending on ext
-    ext = PurePosixPath(data).suffix
-    if ext == ".csv":
-        df = pd.read_csv(data)
-    elif ext == ".gz":
-        df = pd.read_csv(data, compression="gzip")
-    elif ext == ".dta":
-        df = pd.read_stata(data)
-    elif ext == ".feather":
-        df = pd.read_feather(data)
+    if file_path.suffix == ".csv":
+        df = pd.read_csv(file_path)
+    elif file_path.suffix == ".gz":
+        df = pd.read_csv(file_path, compression="gzip")
+    elif file_path.suffix == ".dta":
+        df = pd.read_stata(file_path)
+    elif file_path.suffix == ".feather":
+        df = pd.read_feather(file_path)
     else:
         raise ImportActionError("Unsupported filetype attempted to be imported")
 
     # checks that the variables defined in the json are column names in the
     # csv and raises an error if note
-    for table_names, instructions in variable_json.items():
+    for table_names, instructions in table_configs.items():
         if not set(instructions["variables"]).issubset(df.columns.values):
             raise ImportActionError
 

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -2,7 +2,7 @@
 import itertools
 import os
 import pathlib
-from typing import Dict, Sequence, Union
+from typing import Dict, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -31,17 +31,20 @@ def import_data(file_path: pathlib.Path, table_configs: Dict[str, TableConfig]):
     return table
 
 
-def make_output_dirs(table_config_json, path=None):
+def make_output_dirs(
+    table_configs: Dict[str, TableConfig],
+    base_dir: Optional[str] = None,
+):
     """
     Makes the output folders for the markdown files to land into based on the json
     provided
     """
-    folder_names = table_config_json
-    if path is None:
+    folder_names = table_configs
+    if base_dir is None:
         for folder_name, table_dets in folder_names.items():
             os.makedirs(folder_name, exist_ok=True)
     else:
-        os.makedirs(path, exist_ok=True)
+        os.makedirs(base_dir, exist_ok=True)
         for folder_name, table_dets in folder_names.items():
-            full_path = os.path.join(path, folder_name)
+            full_path = os.path.join(base_dir, folder_name)
             os.makedirs(full_path, exist_ok=True)

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -2,7 +2,7 @@
 import itertools
 import os
 import pathlib
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Iterable, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -31,24 +31,17 @@ def import_data(file_path: pathlib.Path, table_configs: Dict[str, TableConfig]):
     return table
 
 
-def make_output_dirs(
-    table_configs: Dict[str, TableConfig],
-    base_dir: Optional[str] = None,
-):
+def make_output_dirs(table_names: Iterable[str], base_dir: Optional[str] = None):
     """Makes output directories for tables and log files.
 
     Args:
-        table_configs: A mapping of table names to table configurations. The table names
-            are used to make output directories. The table configurations are ignored.
+        table_names: The names of the tables are the names of the output directories.
         base_dir: The base directory, beneath which the output directories are made.
             If `None`, then the base directory is the current directory.
     """
-    folder_names = table_configs
-    if base_dir is None:
-        for folder_name, table_dets in folder_names.items():
-            os.makedirs(folder_name, exist_ok=True)
-    else:
-        os.makedirs(base_dir, exist_ok=True)
-        for folder_name, table_dets in folder_names.items():
-            full_path = os.path.join(base_dir, folder_name)
-            os.makedirs(full_path, exist_ok=True)
+    for table_name in table_names:
+        if base_dir is None:
+            dir_out = table_name
+        else:
+            dir_out = os.path.join(base_dir, table_name)
+        os.makedirs(dir_out, exist_ok=True)

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -31,7 +31,7 @@ def import_data(file_path: pathlib.Path, table_configs: Dict[str, TableConfig]):
     return table
 
 
-def make_folders(table_config_json, path=None):
+def make_output_dirs(table_config_json, path=None):
     """
     Makes the output folders for the markdown files to land into based on the json
     provided

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -12,11 +12,7 @@ TableConfig = Dict[str, Union[str, Sequence[str]]]
 
 
 def import_data(file_path: pathlib.Path, table_configs: Dict[str, TableConfig]):
-    """
-    Imports data and checks that the variables are present
-
-    Will accept input file as csv or dta file (stata).
-    """
+    """Imports data, checking that the required variables are present."""
     if file_path.suffix == ".csv":
         table = pd.read_csv(file_path)
     elif file_path.suffix == ".gz":

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -35,9 +35,13 @@ def make_output_dirs(
     table_configs: Dict[str, TableConfig],
     base_dir: Optional[str] = None,
 ):
-    """
-    Makes the output folders for the markdown files to land into based on the json
-    provided
+    """Makes output directories for tables and log files.
+
+    Args:
+        table_configs: A mapping of table names to table configurations. The table names
+            are used to make output directories. The table configurations are ignored.
+        base_dir: The base directory, beneath which the output directories are made.
+            If `None`, then the base directory is the current directory.
     """
     folder_names = table_configs
     if base_dir is None:

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -1,4 +1,3 @@
-""" this contains useful functions for loading and saving data tables"""
 import itertools
 import os
 import pathlib

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -8,7 +8,7 @@ def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
     return table.le(threshold).any(axis=None)
 
 
-def process_table_request(table: pd.DataFrame, cols: Sequence, threshold: int = 5):
+def make_crosstab(table: pd.DataFrame, cols: Sequence, threshold: int = 5):
     """Make a crosstab from `cols` in `table`.
 
     If the crosstab would contain numbers less than or equal to `threshold`, then return

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Sequence
 
 import pandas as pd
 
@@ -8,7 +8,7 @@ def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
     return table.le(threshold).any(axis=None)
 
 
-def process_table_request(table: pd.DataFrame, cols: Dict, threshold: int = 5):
+def process_table_request(table: pd.DataFrame, cols: Sequence, threshold: int = 5):
     """Make a crosstab from `cols` in `table`.
 
     If the crosstab would contain numbers less than or equal to `threshold`, then return

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -15,17 +15,9 @@ def process_table_request(table: pd.DataFrame, cols: Dict, threshold: int = 5):
     If the crosstab would contain numbers less than or equal to `threshold`, then return
     "REDACTED" instead.
     """
-    # Make crosstab table
-    table = pd.crosstab(table[cols[0]], table[cols[1]])
-    table_variables = [cols[0], cols[1]]
+    crosstab = pd.crosstab(table[cols[0]], table[cols[1]])
 
-    # Check if redaction needed
-    redaction_needed = contains_small_numbers(table=table, threshold=threshold)
+    if contains_small_numbers(table=crosstab, threshold=threshold):
+        return cols, "REDACTED"
 
-    # if redacted needed then return redacted table
-    if redaction_needed:
-        final_table = "REDACTED"
-    else:
-        final_table = table
-
-    return table_variables, final_table
+    return cols, crosstab

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -9,18 +9,18 @@ def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
     return table.le(threshold).any(axis=None)
 
 
-def process_table_request(df: pd.DataFrame, variables: Dict, small_no_limit: int = 5):
+def process_table_request(table: pd.DataFrame, cols: Dict, threshold: int = 5):
     """
     Take one table request and processes. It creates the table, and if
     cell counts 5 or less in any cell, it redacts the whole table. It keeps
     the title of the table.
     """
     # Make crosstab table
-    table = pd.crosstab(df[variables[0]], df[variables[1]])
-    table_variables = [variables[0], variables[1]]
+    table = pd.crosstab(table[cols[0]], table[cols[1]])
+    table_variables = [cols[0], cols[1]]
 
     # Check if redaction needed
-    redaction_needed = contains_small_numbers(table=table, threshold=small_no_limit)
+    redaction_needed = contains_small_numbers(table=table, threshold=threshold)
 
     # if redacted needed then return redacted table
     if redaction_needed:

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -6,21 +6,7 @@ import pandas as pd
 
 def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
     """Does `table` contain numbers less than or equal to `threshold`?"""
-    # Convert table into list for iteration
-    all_values = table.values.tolist()
-
-    # set condition_met to False to start with. This changes if limit breached
-    condition_met = False
-
-    # check if retraction needs to occur based on threshold. Default is 5.
-    for column in all_values:
-        for item in column:
-            if isinstance(item, str):
-                pass
-            elif item <= threshold:
-                condition_met = True
-
-    return condition_met
+    return table.le(threshold).any(axis=None)
 
 
 def process_table_request(df: pd.DataFrame, variables: Dict, small_no_limit: int = 5):

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -10,10 +10,10 @@ def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
 
 
 def process_table_request(table: pd.DataFrame, cols: Dict, threshold: int = 5):
-    """
-    Take one table request and processes. It creates the table, and if
-    cell counts 5 or less in any cell, it redacts the whole table. It keeps
-    the title of the table.
+    """Make a crosstab from `cols` in `table`.
+
+    If the crosstab would contain numbers less than or equal to `threshold`, then return
+    "REDACTED" instead.
     """
     # Make crosstab table
     table = pd.crosstab(table[cols[0]], table[cols[1]])

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pandas as pd
 
 
-def check_for_low_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
+def contains_small_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
     """Does `table` contain numbers less than or equal to `threshold`?"""
     # Convert table into list for iteration
     all_values = table.values.tolist()
@@ -34,7 +34,7 @@ def process_table_request(df: pd.DataFrame, variables: Dict, small_no_limit: int
     table_variables = [variables[0], variables[1]]
 
     # Check if redaction needed
-    redaction_needed = check_for_low_numbers(table=table, threshold=small_no_limit)
+    redaction_needed = contains_small_numbers(table=table, threshold=small_no_limit)
 
     # if redacted needed then return redacted table
     if redaction_needed:

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -1,4 +1,3 @@
-""" Tools for redaction """
 from typing import Dict
 
 import pandas as pd

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -5,18 +5,7 @@ import pandas as pd
 
 
 def check_for_low_numbers(table: pd.DataFrame, small_no_limit: int = 5) -> bool:
-    """
-    Takes in a dataframe such as 2x2 contingency table and checks each value
-    to see if any cell values are small numbers.
-
-    Args:
-        table (Dataframe): table to be redacted
-        small_no_limit (int): the number at which values should be redacted. Defaults to
-            5.
-
-    returns
-        boolean (redaction_needed): True if needs redaction, False if not.
-    """
+    """Does `table` contain numbers less than or equal to `small_no_limit`?"""
     # Convert table into list for iteration
     all_values = table.values.tolist()
 

--- a/action/redaction_tools.py
+++ b/action/redaction_tools.py
@@ -4,20 +4,20 @@ from typing import Dict
 import pandas as pd
 
 
-def check_for_low_numbers(table: pd.DataFrame, small_no_limit: int = 5) -> bool:
-    """Does `table` contain numbers less than or equal to `small_no_limit`?"""
+def check_for_low_numbers(table: pd.DataFrame, threshold: int = 5) -> bool:
+    """Does `table` contain numbers less than or equal to `threshold`?"""
     # Convert table into list for iteration
     all_values = table.values.tolist()
 
     # set condition_met to False to start with. This changes if limit breached
     condition_met = False
 
-    # check if retraction needs to occur based on small_no_limit. Default is 5.
+    # check if retraction needs to occur based on threshold. Default is 5.
     for column in all_values:
         for item in column:
             if isinstance(item, str):
                 pass
-            elif item <= small_no_limit:
+            elif item <= threshold:
                 condition_met = True
 
     return condition_met
@@ -34,7 +34,7 @@ def process_table_request(df: pd.DataFrame, variables: Dict, small_no_limit: int
     table_variables = [variables[0], variables[1]]
 
     # Check if redaction needed
-    redaction_needed = check_for_low_numbers(table=table, small_no_limit=small_no_limit)
+    redaction_needed = check_for_low_numbers(table=table, threshold=small_no_limit)
 
     # if redacted needed then return redacted table
     if redaction_needed:

--- a/tests/test_create_tables.py
+++ b/tests/test_create_tables.py
@@ -29,7 +29,7 @@ def test_prettify_tables():
     no_redaction_needed_variables = ["sex", "copd"]
     test = import_data(correct_json_dict, data=TEST_DATA_CSV)
     variables, test_table = process_table_request(
-        test, variables=no_redaction_needed_variables
+        test, cols=no_redaction_needed_variables
     )
 
     output_str = prettify_tables(table=test_table, variables=variables)

--- a/tests/test_create_tables.py
+++ b/tests/test_create_tables.py
@@ -1,6 +1,6 @@
 from action.create_tables import output_tables, prettify_tables
 from action.find_save_tools import import_data
-from action.redaction_tools import process_table_request
+from action.redaction_tools import make_crosstab
 
 TEST_DATA_CSV = "tests/test_data/test_data.csv"
 
@@ -28,9 +28,7 @@ def test_prettify_tables():
     # set up table
     no_redaction_needed_variables = ["sex", "copd"]
     test = import_data(correct_json_dict, data=TEST_DATA_CSV)
-    variables, test_table = process_table_request(
-        test, cols=no_redaction_needed_variables
-    )
+    variables, test_table = make_crosstab(test, cols=no_redaction_needed_variables)
 
     output_str = prettify_tables(table=test_table, variables=variables)
     assert isinstance(output_str, str)

--- a/tests/test_create_tables.py
+++ b/tests/test_create_tables.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from action.create_tables import output_tables, prettify_tables
 from action.find_save_tools import import_data
 from action.redaction_tools import make_crosstab
@@ -27,7 +29,7 @@ def test_prettify_tables():
 
     # set up table
     no_redaction_needed_variables = ["sex", "copd"]
-    test = import_data(correct_json_dict, data=TEST_DATA_CSV)
+    test = import_data(pathlib.Path(TEST_DATA_CSV), correct_json_dict)
     variables, test_table = make_crosstab(test, cols=no_redaction_needed_variables)
 
     output_str = prettify_tables(table=test_table, variables=variables)

--- a/tests/test_find_and_save_tools.py
+++ b/tests/test_find_and_save_tools.py
@@ -1,41 +1,46 @@
+from unittest import mock
+
+import pandas as pd
 import pytest
 
 from action.errors import ImportActionError
 from action.find_save_tools import import_data
 
-TEST_DATA_CSV = "tests/test_data/test_data.csv"
 
-correct_json_dict = {
-    "simple_2_way_tabs": {
-        "tab_type": "2-way",
-        "variables": ["sex", "ageband", "copd", "death"],
-    }
-}
+class TestImportData:
+    @mock.patch("action.find_save_tools.pd.read_csv", return_value=pd.DataFrame())
+    def test_import_csv_data(self, mocked):
+        import_data({}, "data.csv")
+        mocked.assert_called_once_with("data.csv")
 
-bad_json_dict = {
-    "simple_2_way_tabs": {
-        "tab_type": "2-way",
-        "variables": ["sex", "test", "copd", "death"],
-    }
-}
+    @mock.patch("action.find_save_tools.pd.read_csv", return_value=pd.DataFrame())
+    def test_import_csv_gz_data(self, mocked):
+        import_data({}, "data.csv.gz")
+        mocked.assert_called_once_with("data.csv.gz", compression="gzip")
 
+    @mock.patch("action.find_save_tools.pd.read_stata", return_value=pd.DataFrame())
+    def test_import_dta_data(self, mocked):
+        import_data({}, "data.dta")
+        mocked.assert_called_once_with("data.dta")
 
-def test_import_data():
-    # Import test data
-    test = import_data(correct_json_dict, data=TEST_DATA_CSV)
+    @mock.patch("action.find_save_tools.pd.read_feather", return_value=pd.DataFrame())
+    def test_import_feather_data(self, mocked):
+        import_data({}, "data.feather")
+        mocked.assert_called_once_with("data.feather")
 
-    # Check expected 60 rows in dataframe of test data
-    assert len(test.index) == 60
+    def test_import_unsupported_file_type(self):
+        with pytest.raises(ImportActionError):
+            import_data({}, "data.xlsx")
 
-    # Check column names match
-    assert list(test.columns.values) == [
-        "patient_id",
-        "sex",
-        "ageband",
-        "copd",
-        "death",
-    ]
+    @mock.patch("action.find_save_tools.pd.read_csv")
+    def test_variables_are_columns(self, mocked):
+        mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
+        import_data({"my_table": {"variables": ["sex", "has_condition"]}}, "data.csv")
+        # We're testing that an error wasn't raised, so we don't need to assert
+        # anything.
 
-    # Checks if raises an error if json does not match the csv columns.
-    with pytest.raises(ImportActionError):
-        import_data(bad_json_dict, data=TEST_DATA_CSV)
+    @mock.patch("action.find_save_tools.pd.read_csv")
+    def test_variables_are_not_columns(self, mocked):
+        mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
+        with pytest.raises(ImportActionError):
+            import_data({"my_table": {"variables": ["sex", "age_band"]}}, "data.csv")

--- a/tests/test_find_and_save_tools.py
+++ b/tests/test_find_and_save_tools.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest import mock
 
 import pandas as pd
@@ -10,32 +11,35 @@ from action.find_save_tools import import_data
 class TestImportData:
     @mock.patch("action.find_save_tools.pd.read_csv", return_value=pd.DataFrame())
     def test_import_csv_data(self, mocked):
-        import_data({}, "data.csv")
-        mocked.assert_called_once_with("data.csv")
+        import_data(pathlib.Path("data.csv"), {})
+        mocked.assert_called_once_with(pathlib.Path("data.csv"))
 
     @mock.patch("action.find_save_tools.pd.read_csv", return_value=pd.DataFrame())
     def test_import_csv_gz_data(self, mocked):
-        import_data({}, "data.csv.gz")
-        mocked.assert_called_once_with("data.csv.gz", compression="gzip")
+        import_data(pathlib.Path("data.csv.gz"), {})
+        mocked.assert_called_once_with(pathlib.Path("data.csv.gz"), compression="gzip")
 
     @mock.patch("action.find_save_tools.pd.read_stata", return_value=pd.DataFrame())
     def test_import_dta_data(self, mocked):
-        import_data({}, "data.dta")
-        mocked.assert_called_once_with("data.dta")
+        import_data(pathlib.Path("data.dta"), {})
+        mocked.assert_called_once_with(pathlib.Path("data.dta"))
 
     @mock.patch("action.find_save_tools.pd.read_feather", return_value=pd.DataFrame())
     def test_import_feather_data(self, mocked):
-        import_data({}, "data.feather")
-        mocked.assert_called_once_with("data.feather")
+        import_data(pathlib.Path("data.feather"), {})
+        mocked.assert_called_once_with(pathlib.Path("data.feather"))
 
     def test_import_unsupported_file_type(self):
         with pytest.raises(ImportActionError):
-            import_data({}, "data.xlsx")
+            import_data(pathlib.Path("data.xlsx"), {})
 
     @mock.patch("action.find_save_tools.pd.read_csv")
     def test_variables_are_columns(self, mocked):
         mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
-        import_data({"my_table": {"variables": ["sex", "has_condition"]}}, "data.csv")
+        import_data(
+            pathlib.Path("data.csv"),
+            {"my_table": {"variables": ["sex", "has_condition"]}},
+        )
         # We're testing that an error wasn't raised, so we don't need to assert
         # anything.
 
@@ -43,4 +47,7 @@ class TestImportData:
     def test_variables_are_not_columns(self, mocked):
         mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
         with pytest.raises(ImportActionError):
-            import_data({"my_table": {"variables": ["sex", "age_band"]}}, "data.csv")
+            import_data(
+                pathlib.Path("data.csv"),
+                {"my_table": {"variables": ["sex", "age_band"]}},
+            )

--- a/tests/test_find_and_save_tools.py
+++ b/tests/test_find_and_save_tools.py
@@ -54,23 +54,17 @@ class TestImportData:
             import_data(pathlib.Path("data.xlsx"), {})
 
     @mock.patch("action.find_save_tools.pd.read_csv")
-    def test_variables_are_columns(self, mocked):
-        mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
-        import_data(
-            pathlib.Path("data.csv"),
-            {"my_table": {"variables": ["sex", "has_condition"]}},
-        )
+    def test_variables_are_columns(self, mocked, table_configs):
+        mocked.return_value = pd.DataFrame(columns=["sex", "age_band", "has_copd"])
+        import_data(pathlib.Path("data.csv"), table_configs)
         # We're testing that an error wasn't raised, so we don't need to assert
         # anything.
 
     @mock.patch("action.find_save_tools.pd.read_csv")
-    def test_variables_are_not_columns(self, mocked):
-        mocked.return_value = pd.DataFrame(columns=["sex", "has_condition"])
+    def test_variables_are_not_columns(self, mocked, table_configs):
+        mocked.return_value = pd.DataFrame(columns=["sex", "age_band"])  # no has_copd
         with pytest.raises(ImportActionError):
-            import_data(
-                pathlib.Path("data.csv"),
-                {"my_table": {"variables": ["sex", "age_band"]}},
-            )
+            import_data(pathlib.Path("data.csv"), table_configs)
 
 
 @mock.patch("os.makedirs")

--- a/tests/test_find_and_save_tools.py
+++ b/tests/test_find_and_save_tools.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from action.errors import ImportActionError
-from action.find_save_tools import import_data, make_folders
+from action.find_save_tools import import_data, make_output_dirs
 
 
 @pytest.fixture
@@ -76,7 +76,7 @@ class TestImportData:
 @mock.patch("os.makedirs")
 class TestMakeOutputDirs:
     def test_with_base_dir(self, mocked, table_configs):
-        make_folders(table_configs, "my_base_dir")
+        make_output_dirs(table_configs, "my_base_dir")
         mocked.assert_has_calls(
             [
                 mock.call("my_base_dir", exist_ok=True),
@@ -87,7 +87,7 @@ class TestMakeOutputDirs:
         )
 
     def test_without_base_dir(self, mocked, table_configs):
-        make_folders(table_configs)
+        make_output_dirs(table_configs)
         mocked.assert_has_calls(
             [
                 mock.call("my_two_way", exist_ok=True),

--- a/tests/test_find_and_save_tools.py
+++ b/tests/test_find_and_save_tools.py
@@ -79,7 +79,6 @@ class TestMakeOutputDirs:
         make_output_dirs(table_configs, "my_base_dir")
         mocked.assert_has_calls(
             [
-                mock.call("my_base_dir", exist_ok=True),
                 mock.call("my_base_dir/my_two_way", exist_ok=True),
                 mock.call("my_base_dir/my_target_two_way", exist_ok=True),
                 mock.call("my_base_dir/my_groupby_two_way", exist_ok=True),

--- a/tests/test_redaction_tools.py
+++ b/tests/test_redaction_tools.py
@@ -15,11 +15,11 @@ correct_json_dict = {
 
 class TestContainsSmallNumbers:
     def test_contains_small_numbers(self):
-        table = pd.DataFrame({"test_col_1": [1, 10], "test_col_2": [20, 40]})
+        table = pd.DataFrame({"col_1": [5, 6], "col_2": [6, 6]})
         assert check_for_low_numbers(table)
 
     def test_does_not_contain_small_numbers(self):
-        table = pd.DataFrame({"test_col_1": [10, 20], "test_col_2": [20, 40]})
+        table = pd.DataFrame({"col_1": [6, 6], "col_2": [6, 6]})
         assert not check_for_low_numbers(table)
 
 

--- a/tests/test_redaction_tools.py
+++ b/tests/test_redaction_tools.py
@@ -3,7 +3,7 @@ import itertools
 import pandas as pd
 from pandas import testing
 
-from action.redaction_tools import contains_small_numbers, process_table_request
+from action.redaction_tools import contains_small_numbers, make_crosstab
 
 
 class TestContainsSmallNumbers:
@@ -28,7 +28,7 @@ class TestMakeCrosstab:
         table = self.table_factory(5)
         cols = list(table.columns)
 
-        obs_cols, obs_table = process_table_request(table, cols)
+        obs_cols, obs_table = make_crosstab(table, cols)
         exp_cols, exp_table = cols, "REDACTED"
 
         assert obs_cols == exp_cols
@@ -38,7 +38,7 @@ class TestMakeCrosstab:
         table = self.table_factory(6)
         cols = list(table.columns)
 
-        obs_cols, obs_table = process_table_request(table, cols)
+        obs_cols, obs_table = make_crosstab(table, cols)
         exp_cols = cols
         exp_table = pd.DataFrame(
             [[6, 6], [6, 6]],

--- a/tests/test_redaction_tools.py
+++ b/tests/test_redaction_tools.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from action.find_save_tools import import_data
-from action.redaction_tools import check_for_low_numbers, process_table_request
+from action.redaction_tools import contains_small_numbers, process_table_request
 
 TEST_DATA_CSV = "tests/test_data/test_data.csv"
 
@@ -16,11 +16,11 @@ correct_json_dict = {
 class TestContainsSmallNumbers:
     def test_contains_small_numbers(self):
         table = pd.DataFrame({"col_1": [5, 6], "col_2": [6, 6]})
-        assert check_for_low_numbers(table)
+        assert contains_small_numbers(table)
 
     def test_does_not_contain_small_numbers(self):
         table = pd.DataFrame({"col_1": [6, 6], "col_2": [6, 6]})
-        assert not check_for_low_numbers(table)
+        assert not contains_small_numbers(table)
 
 
 def test_process_table_request():

--- a/tests/test_redaction_tools.py
+++ b/tests/test_redaction_tools.py
@@ -1,16 +1,9 @@
+import itertools
+
 import pandas as pd
+from pandas import testing
 
-from action.find_save_tools import import_data
 from action.redaction_tools import contains_small_numbers, process_table_request
-
-TEST_DATA_CSV = "tests/test_data/test_data.csv"
-
-correct_json_dict = {
-    "simple_2_way_tabs": {
-        "tab_type": "2-way",
-        "variables": ["sex", "ageband", "copd", "death"],
-    }
-}
 
 
 class TestContainsSmallNumbers:
@@ -23,27 +16,35 @@ class TestContainsSmallNumbers:
         assert not contains_small_numbers(table)
 
 
-def test_process_table_request():
-    no_redaction_needed_variables = ["sex", "copd"]
-    redaction_needed_variables = ["ageband", "sex"]
+class TestMakeCrosstab:
+    @staticmethod
+    def table_factory(num_repeated_rows):
+        return pd.DataFrame(
+            list(itertools.product(["F", "M"], [0, 1])) * num_repeated_rows,
+            columns=("sex", "has_condition"),
+        )
 
-    # Import test data
-    test = import_data(correct_json_dict, data=TEST_DATA_CSV)
+    def test_contains_small_numbers(self):
+        table = self.table_factory(5)
+        cols = list(table.columns)
 
-    # pick 2 variables which have sufficient numbers to require no redaction
-    variables, test_table = process_table_request(
-        test, variables=no_redaction_needed_variables
-    )
+        obs_cols, obs_table = process_table_request(table, cols)
+        exp_cols, exp_table = cols, "REDACTED"
 
-    # check values are correct
-    # first row should be female sex. There are 16 women with copd, 16 without
-    assert test_table.iloc[0][0] == 16
+        assert obs_cols == exp_cols
+        assert obs_table == exp_table
 
-    # pick 2 variables which have sufficient numbers to require no redaction
-    variables2, test_table_2 = process_table_request(
-        test, variables=redaction_needed_variables
-    )
+    def test_does_not_contain_small_numbers(self):
+        table = self.table_factory(6)
+        cols = list(table.columns)
 
-    # assert redacted
-    # print("TABLE 2: ", test_table_2)
-    assert test_table_2 == "REDACTED"
+        obs_cols, obs_table = process_table_request(table, cols)
+        exp_cols = cols
+        exp_table = pd.DataFrame(
+            [[6, 6], [6, 6]],
+            index=pd.Index(["F", "M"], name="sex"),
+            columns=pd.Index([0, 1], name="has_condition"),
+        )
+
+        assert obs_cols == exp_cols
+        testing.assert_frame_equal(obs_table, exp_table)

--- a/tests/test_redaction_tools.py
+++ b/tests/test_redaction_tools.py
@@ -13,20 +13,14 @@ correct_json_dict = {
 }
 
 
-def test_check_for_low_numbers():
-    no_redact_data = {"test_col_1": [10, 20], "test_col_2": [20, 40]}
-    no_redact_df = pd.DataFrame(data=no_redact_data)
+class TestContainsSmallNumbers:
+    def test_contains_small_numbers(self):
+        table = pd.DataFrame({"test_col_1": [1, 10], "test_col_2": [20, 40]})
+        assert check_for_low_numbers(table)
 
-    # use check_for_low_numbers() on a dataframe that does not require redaction
-    result = check_for_low_numbers(table=no_redact_df, small_no_limit=5)
-    assert result is False
-
-    need_redact_data = {"test_col_1": [1, 10], "test_col_2": [20, 40]}
-    need_redact_df = pd.DataFrame(data=need_redact_data)
-
-    # use check_for_low_numbers() on a dataframe that does require redaction
-    result2 = check_for_low_numbers(table=need_redact_df, small_no_limit=5)
-    assert result2 is True
+    def test_does_not_contain_small_numbers(self):
+        table = pd.DataFrame({"test_col_1": [10, 20], "test_col_2": [20, 40]})
+        assert not check_for_low_numbers(table)
 
 
 def test_process_table_request():


### PR DESCRIPTION
Assorted refactorings of the redaction, crosstab, and import functionality. Draft, at present, because I'd like to finish by refactoring `find_save_tools.make_folders`.

I'm trying to go step-by-step with these commits. First, working on tests; then on docstrings; then on arguments and signatures; and finally the functions themselves. However, I'm also mindful of addressing the following issues, either in the PR or in future refactorings:

* Running the tests shouldn't write files to the project directory
* Adding assertions to all tests, unless explicitly stated
* Replacing fixture files with fixture functions/factory functions
* Sticking to a single docstring style, without type hints in the docstrings themselves
* Typing all functions with the exception of protected (`_*`) and private (`__*`) functions
* Adding return type annotations
* Simplifying confusing module names
* Consistent variable names -- avoiding `df` for Pandas data frames