### PR TITLE
Configure bump2version to bump README.md

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,14 @@
+# Extra configuration for bump2version
+#
+# For consistency with other opensafely-actions, we also pass configuration in
+# scripts/bump. For more information about bump2version, see:
+# https://pypi.org/project/bump2version/
+
+[bumpversion]
+
+# Unfortunately, bump2version insists that the current version is stored here,
+# even when we pass it in scripts/bump.
+current_version = 3.0.0
+
+# Also bump version strings in the following files.
+[bumpversion:file:README.md]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,14 +1,12 @@
-# Extra configuration for bump2version
-#
-# For consistency with other opensafely-actions, we also pass configuration in
-# scripts/bump. For more information about bump2version, see:
+# Configuration for bump2version. For more information, see:
 # https://pypi.org/project/bump2version/
 
 [bumpversion]
-
-# Unfortunately, bump2version insists that the current version is stored here,
-# even when we pass it in scripts/bump.
 current_version = 3.0.0
+commit = True
+tag = True
 
-# Also bump version strings in the following files.
+# Also bump the version string in the following files.
 [bumpversion:file:README.md]
+
+[bumpversion:file:action/VERSION]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define USAGE
 Run commands for a project
 
 Commands:
-	bump		Bumps the version string in action/VERSION, creating a annotated tag for the new version and a commit for action/VERSION. Must be passed major, minor, or patch as the argument
+	bump		Bumps the version string to the next major, minor, or patch version. Must be passed major, minor, or patch as the argument
 	check    	Runs black, isort, and flake8 over all Python files but does not make changes
 	dev_setup  	Sets up development environment
 	fix      	Runs black and isort over all Python files and makes changes

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ actions:
         cohort: output/input.csv
 
   generate_safetabs:
-    run: safetab:v2.0 output/input.csv
+    run: safetab:v3.0.0 output/input.csv
     needs: [generate_study_population]
     config:
       output_path: output
@@ -42,7 +42,7 @@ actions:
 The `generate_safetabs` action outputs one table: `sex` vs `age_band`.
 Notice the `run` and `config` properties.
 The `run` property passes a specific input table to a specific version of safetab.
-In this case, the specific input table is *output/input.csv* and the specific version of safetab is v2.0.
+In this case, the specific input table is *output/input.csv* and the specific version of safetab is v3.0.0.
 The `config` property passes configuration to safetab; for more information, see *Configuration*.
 
 ### Configuration

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,10 +1,8 @@
 #!/bin/bash
-# Bumps the version string in action/VERSION, creating a annotated tag for the new
-# version and a commit for action/VERSION.
+# Bumps the version string to the next major, minor, or patch version.
 
 set -euo pipefail
 
-current_version="`cat action/VERSION`"
 version_type="$1"
 
-$VIRTUAL_ENV/bin/bump2version --current-version $current_version --tag --commit $version_type action/VERSION
+$VIRTUAL_ENV/bin/bump2version $version_type


### PR DESCRIPTION
Anyone copying-and-pasting from README.md will always copy-and-paste the latest version of safetab.