### PR TITLE
Add github actions from python-action-template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+---
+name: CI
+
+on:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      - name: "Install dependencies"
+        run: |
+          set -xe
+          python -m venv venv
+          venv/bin/pip install --upgrade pip
+          venv/bin/pip install --progress-bar=off --require-hashes --requirement requirements.dev.txt
+      - run: ls -lah ${{ github.workspace }}
+      - name: Check formatting, linting and import sorting
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          ./scripts/check
+
+  test:
+    needs: [check]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      - name: "Install dependencies"
+        run: |
+          set -xe
+          python -m venv venv
+          venv/bin/pip install --upgrade pip
+          venv/bin/pip install --progress-bar=off --require-hashes --requirement requirements.dev.txt
+      - name: Run tests
+#       env:  # Add environment variables required for tests
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          ./scripts/test

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,0 +1,43 @@
+name: Setup repository
+on:
+  workflow_dispatch:
+  push:
+      branches: [main]
+jobs:
+  setup:
+    name: Initialise OpenSAFELY repo.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update README.md and remove action
+        shell: bash
+        run: |
+          export GITHUB_REPOSITORY_OWNER="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $1}')"
+          export GITHUB_REPOSITORY_NAME="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $2}')"
+          envsubst < README.md > tmp && mv tmp README.md
+          rm .github/workflows/setup.yml
+      - name: Do not run on template repository
+        id: is_template
+        # The only way to trigger this to run when used as a template is on
+        # push to main.  But that means it would also trigger when we push to
+        # the template repo itself, which we do not want. So, check if we are
+        # in a template repo
+        run: |
+          is_template=false
+          curl --silent -X GET \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.baptiste-preview+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY \
+            | jq --exit-status '.is_template == false' || is_template=true
+          # output true/false so later actions can be skipped
+          echo "::set-output name=is_template::$is_template"
+      - name: Commit changes
+        # only actually commit the changes if this is not a template repo
+        if: steps.is_template.outputs.is_template == 'false'
+        run: |
+          # use the same author as the initial commit
+          git config user.email "$(git log -1 --pretty=format:'%ae')"
+          git config user.name "$(git log -1 --pretty=format:'%an')"
+          git add .
+          git commit --amend --no-edit
+          git push origin $GITHUB_REF --force

--- a/action/__main__.py
+++ b/action/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import errno
 import json
 import os
 from pathlib import Path
@@ -23,7 +24,7 @@ def convert_config(file_or_string: str) -> Dict:
     try:
         path_exists = path.exists()
     except OSError as e:
-        if e.errno == 63:  # File name too long
+        if e.errno == errno.ENAMETOOLONG:  # File name too long
             # The name component of the path is too long for the file system. It's
             # likely that `file_or_string` is a string, so we won't re-raise the error.
             path_exists = False


### PR DESCRIPTION
A straightforward copy from `python-action-template` to here and, as a bonus, fix a bug that I couldn't recreate locally but is causing failures [elsewhere](https://github.com/opensafely-actions/test-reusable-actions/runs/3483221068?check_suite_focus=true) 🥳 